### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - pip install .
   - pip install coveralls
 # command to run tests, e.g. python setup.py test
-env: PYGAC_CONFIG_FILE=bla
+env: PYGAC_CONFIG_FILE=etc/pygac.cfg.template
 script: coverage run --source=pygac setup.py test
 before_install:
   - sudo apt-get install -qq python-numpy python-h5py python-scipy libhdf5-serial-dev


### PR DESCRIPTION
The new tests require a config file with the expected sections
to be present. However, its contents will not be used so that
we can let PYGAC_CONFIG_FILE point to etc/pygac.cfg.template .